### PR TITLE
fix:'property split does not exist on type never' error

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,6 @@
 export interface TProps {
   children: React.ReactNode;
-  languages: { [key: string]: {} };
+  languages: Record<string, any>;
   defaultLanguage: string;
   detectBrowserLanguage?: boolean;
 }
@@ -8,7 +8,7 @@ export interface TProps {
 export interface TContext {
   locale: string;
   setLocale: (language: string) => void;
-  languages: { [key: string]: {} };
+  languages: Record<string, any>;
   defaultLanguage: string;
 }
 
@@ -19,7 +19,7 @@ export type KeyPath<T> = (
     ? {
         [K in Exclude<keyof T, symbol>]: `${K}${KeyPrefix<KeyPath<T[K]>>}`;
       }[Exclude<keyof T, symbol>]
-    : ""
+    : string
 ) extends infer D
   ? Extract<D, string>
   : never;

--- a/src/t.tsx
+++ b/src/t.tsx
@@ -19,7 +19,6 @@ export function T(
     let plural = new Intl.PluralRules(currentLocale).select(
       params.count as number
     );
-    //@ts-ignore
     currentKey =
       params.count === 0
         ? `${key}.zero`
@@ -27,7 +26,6 @@ export function T(
         ? `${key}.many`
         : `${key}.${plural}`;
   }
-  //@ts-ignore
   currentKey.split(".").forEach((k: string) => {
     if (!result[k]) return;
     return (result = result[k]);
@@ -44,7 +42,6 @@ export function T(
     ) as TParams["params"]);
   return currentParams
     ? result
-        //@ts-ignore
         .split("__")
         .map((word: string) =>
           currentParams[word] ? currentParams[word] : word


### PR DESCRIPTION
I haven't tested this locally in a project as I have a separate issue trying to run that, but it fixes the type error for currentKey in editor.