### PR TITLE
feat: improve autocompletion typing

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -16,19 +16,24 @@ export type TrContext = Omit<TContext, "setLocale">;
 
 type KeyPrefix<T extends string> = T extends "" ? "" : `.${T}`;
 
+type Suffix = "zero" | "one" | "two" | "few" | "many" | "female" | "male";
+type DynamicSuffix = Partial<Record<Suffix, string>>;
+
 export type KeyPath<T> = (
-  T extends object
-    ? {
+  T extends DynamicSuffix
+    ? ""
+    : T extends object 
+      ? {
         [K in Exclude<keyof T, symbol>]: `${K}${KeyPrefix<KeyPath<T[K]>>}`;
       }[Exclude<keyof T, symbol>]
-    : ""
+      : ""
 ) extends infer D
   ? Extract<D, string>
   : never;
 
 export type TParams = { count?: number; [key: string]: any };
 
-export type Autocomplete<schema> = KeyPath<schema> | (string & {});
+export type Autocomplete<schema> = KeyPath<schema>;
 
 export interface UseT extends TContext {
   T: <Key extends string, Params extends TParams>(


### PR DESCRIPTION
Hello ! 
Thank you for this library. 🙏
I use it on my project. 👌🏻
Unfortunately, Sonarqube tells me this :
> `KeyPath<schema> | (string & {});`
> Remove this type without members or change this type intersection. Types without members, 'any' and 'never' should not be used in type intersections.  

So I modified the type to handle this.